### PR TITLE
Refocus CLAUDE.md on GitHub platform configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [v0.12] - 2025-01-09
+
+### Changed
+- CLAUDE.md rewritten to focus on GitHub platform configuration (CI/CD, branch protection, Dependabot)
+- Vision, architecture, and conventions moved to homestak-dev/CLAUDE.md
+
+### Removed
+- Org-level documentation moved to homestak-dev parent repo:
+  - RELEASE.md (release methodology)
+  - REPO-SETTINGS.md (repository standards)
+  - CLAUDE-GUIDELINES.md (documentation standards)


### PR DESCRIPTION
## Summary
- Rewrite CLAUDE.md to focus on GitHub platform configuration:
  - CI/CD patterns and workflows
  - Branch protection settings
  - Dependabot configuration
  - Secret scanning
- Move vision, architecture, conventions to homestak-dev/CLAUDE.md
- Add CHANGELOG.md

## Test plan
- [x] Integration test (vm-roundtrip) passed
- [ ] Verify links to homestak-dev/CLAUDE.md work
- [ ] Review CI/CD documentation accuracy

Part of v0.12 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)